### PR TITLE
Create Claude.MD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,122 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a standalone Web Component for building TRMNL custom plugin form fields. It's a single-file JavaScript component (`trmnl-form-builder.js`, ~2400 lines) that registers as `<trmnl-form-builder>` and provides a visual form builder that outputs YAML configuration files. The component has no JavaScript dependencies and only requires Tailwind CSS for styling.
+
+## Commands
+
+### Testing
+- `pnpm test` - Run all tests once
+- `pnpm run test:watch` - Run tests in watch mode
+- `pnpm run test:ui` - Run tests with Vitest UI
+- `pnpm run test:coverage` - Run tests with coverage report
+
+### Development
+- No build step required - the component is a single vanilla JS file
+- Open `index.html` in a browser to test the component locally
+- The component uses ES modules and the Custom Elements API
+
+## Architecture
+
+### Component Structure
+
+The entire component is implemented as a single `TRMLYamlForm` class that extends `HTMLElement`. Key architectural points:
+
+1. **Shadow DOM**: Uses Shadow DOM for style encapsulation with all styles defined inline in the component
+2. **State Management**: Fields array (`this.fields`) holds all form field definitions, each with a unique ID
+3. **Reactive Rendering**: Changes trigger `render()` which regenerates the entire UI and YAML output
+4. **No External Dependencies**: Pure vanilla JavaScript with no bundler or transpilation
+
+### Field Types System
+
+Fields are defined in `this.fieldTypes` (around line 115) with a consistent structure:
+```javascript
+{
+  category: 'TEXT INPUT',  // Groups fields in the UI
+  name: 'String',          // Display name
+  description: 'Single line text',
+  properties: ['default', 'placeholder', 'optional']  // Available settings
+}
+```
+
+Each field type has different allowed properties. Property definitions are in `this.propertyDefinitions` (around line 63) which describe how to render each setting (text input, checkbox, textarea, etc.).
+
+### Property Overrides
+
+Field types can override generic property definitions using objects instead of strings:
+```javascript
+properties: [
+  {
+    key: 'default',
+    placeholder: 'YYYY-MM-DD',
+    help: 'Can also be set to "today"'
+  },
+  'optional'
+]
+```
+
+This allows field-specific behavior for common properties like `default`.
+
+### Key Methods
+
+- `addField(fieldType)` (line ~904) - Creates a new field with auto-generated ID and keyname
+- `deleteField(fieldId)` (line ~2000) - Removes field and cleans up dependencies
+- `generateYaml()` (line ~1735) - Converts fields array to YAML string
+- `render()` (line ~256) - Regenerates entire UI including field list, config panel, and YAML output
+
+### YAML Generation
+
+The YAML generation logic includes:
+- **Escaping**: `escapeYaml()` handles special characters, colons, quotes, and YAML reserved words (true/false/yes/no)
+- **Label:Value pairs**: Select options support "Label:Value" format that splits on first colon
+- **Conditional properties**: Only includes properties that are set (not empty/undefined)
+- **Proper indentation**: Uses 2-space indentation for nested structures
+
+### depends_on System
+
+xhrSelect fields can depend on other xhrSelect fields using `depends_on` property:
+- Parent field must be an xhrSelect type
+- Parent must appear before child in the field list
+- When parent is deleted or reordered after child, `depends_on` is automatically cleared
+- Validation happens in `generateYaml()` with toast notifications for cleared dependencies
+
+### Author Bio Field
+
+Special field type with unique logic:
+- Can only have ONE author_bio field per form
+- Automatically prevents adding more than one
+- Has custom category selection UI (max 2 categories)
+- Categories loaded from `https://trmnl.com/api/categories` with fallback list
+- Category selection uses pill UI rendered by `renderCategoryPills()`
+
+### Public API
+
+Component exposes methods for programmatic control (line ~2381):
+- `getYaml()` - Returns generated YAML string
+- `getFields()` - Returns current fields array
+- `setFields(fields)` - Loads fields from array and re-renders
+- `clear()` - Removes all fields
+
+### Locales
+
+Component includes list of supported locales (`this.locales` around line 37) based on trmnl-i18n. These are used for plugin internationalization.
+
+## Testing
+
+Tests use Vitest with jsdom environment to simulate browser APIs:
+- `unit.test.js` - Tests for YAML escaping/unescaping, step property, boolean field type
+- `depends-on.test.js` - Tests for dependency validation between fields
+- `yaml-operations.test.js` - Tests for YAML import/export functionality
+- `pipe-symbol.test.js` - Tests for pipe character handling in YAML
+- `fixture.test.js` - Tests using complete form fixtures
+- `api-reorder.test.js` - Tests for field reordering logic
+
+Tests create component instances with `document.createElement('trmnl-form-builder')` and call methods directly.
+
+## Known Issues
+
+From README.md:
+- Import functionality doesn't properly parse more complex YAML structures with `|` or `>` multiline operators


### PR DESCRIPTION
Had ChatGPT evaluate the quality of claude.md (generated by Claude Code) as generate by:
- `web.md`: Claude Sonnett/Haiku ($0.30, API)
- `local.md` Qwen3-Coder:30b (local)
It hands-down chose the Claude created file, so I'm adding that. Here was the analysis:
-------
## Verdict up front

**The first one (`web.md`) is clearly better for an LLM agent.**
Not marginally — *structurally and strategically better*.

The second one (`local.md`) reads like human-facing README content that *happens* to be put in `CLAUDE.md`.

Below is why, broken down by how LLMs actually use these files.

---

## How LLM coding agents actually use `agents.md / CLAUDE.md`

LLMs don’t “read” this like a developer. They use it to:

1. Build a **mental map of the codebase**
2. Anchor themselves when answering questions like:

   * “Where should I add this?”
   * “What will break if I change this?”
   * “Is this behavior intentional?”
3. Reduce hallucination by having:

   * Concrete constraints
   * Known invariants
   * Named methods and responsibilities
4. Decide **what *not* to touch**

The first file optimizes for those needs. The second mostly doesn’t.

---

## Why `web.md` is stronger (LLM-centric analysis)

### 1. It anchors the LLM to *real code, not abstractions*

`web.md` constantly ties concepts to **actual implementation artifacts**:

* Specific class name: `TRMLYamlForm`
* Concrete file size (~2400 lines)
* Method names with approximate line numbers:

  * `render()` (~256)
  * `addField()` (~904)
  * `generateYaml()` (~1735)
* Specific object locations:

  * `this.fieldTypes` around line ~115
  * `this.propertyDefinitions` around line ~63

This matters a *lot*.

For an LLM:

* This dramatically reduces “creative refactoring” accidents
* It encourages surgical edits instead of rewrites
* It helps the model *search* internally when reasoning about changes

`local.md` stays abstract:

> “State management for fields, drag/drop operations, and selection”

That’s human-friendly but gives the model nowhere to *land*.

---

### 2. It encodes invariants and hidden constraints

The first file is packed with **rules the LLM should not violate**, for example:

* Only one `author_bio` field allowed
* `depends_on` ordering rules
* Auto-clearing dependencies on delete/reorder
* Escaping rules for YAML reserved words
* Label:value splitting semantics
* Conditional property inclusion rules

These are *exactly* the things LLMs are most likely to break accidentally.

The second file mostly lists features, not constraints.

From an LLM’s POV:

* Features ≠ contracts
* Constraints ≠ optional

`web.md` encodes contracts.

---

### 3. It explains *why* the architecture is the way it is

LLMs are better at respecting design when they understand intent.

Examples from `web.md`:

* “No build step required”
* “Entire UI regenerated on render”
* “No external dependencies”
* “Shadow DOM with inline styles”

This tells the model:

* Don’t introduce frameworks
* Don’t optimize with partial renders
* Don’t extract CSS files
* Don’t add state libraries

`local.md` doesn’t actively *discourage* bad changes.

---

### 4. It names the scary parts explicitly

LLMs need to know where the dragons are 🐉

`web.md` clearly flags:

* YAML escaping complexity
* Import limitations with `|` and `>`
* Dependency validation edge cases
* API fallback behavior

This primes the model to:

* Be cautious
* Add tests
* Avoid refactors in those zones

`local.md` mentions import/export, but not the landmines.

---

### 5. It’s optimized for *task execution*, not onboarding

This is key.

`local.md` is great if:

* You’re a new human contributor
* You want a feature checklist
* You want a marketing-ish overview

`web.md` is great if:

* You’re an autonomous or semi-autonomous agent
* You’re about to modify logic
* You need to reason about side effects

For LLMs, the second goal matters far more.

---

## Where `local.md` *does* have value

To be fair, [local.md](https://github.com/user-attachments/files/25120311/local.md) isn’t bad — it’s just not agent-optimized.

It’s good at:

* High-level feature enumeration
* File structure overview
* Communicating product scope
* Surfacing newer additions like `plugin_instance_select`

If anything, it would be excellent as:

* `README.md`
* `ARCHITECTURE.md`
* Or a **supplement** to `CLAUDE.md`

---

## Final call

**Winner: `web.md`**

Why, in one sentence:

> It treats the LLM like a junior maintainer who needs guardrails, not like a human who just needs a tour.

